### PR TITLE
Fixed opcache reset performance bug

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -990,10 +990,10 @@ class OC {
 			self::checkMaintenanceMode($systemConfig);
 
 			if (\OCP\Util::needUpgrade()) {
-				if (function_exists('opcache_reset')) {
-					opcache_reset();
-				}
 				if (!((bool) $systemConfig->getValue('maintenance', false))) {
+					if (function_exists('opcache_reset')) {
+						opcache_reset();
+					}
 					self::printUpgradePage($systemConfig);
 					exit();
 				}


### PR DESCRIPTION
opcache must only be reset if there needs upgrade AND maintenance is true.

Signed-off-by: Mateus de Lima Oliveira <mateus@ativarsoft.com>